### PR TITLE
Change pipx binary directory

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -17,21 +17,20 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
 		&& apt-get upgrade -y \
-		&& apt-get install \
+		&& apt-get install -y \
 			apt-utils	\
 			git	\
 			wget gnupg curl \
 			build-essential \
 			libz-dev \
-			gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
-			-y
+			gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
 # dpkg --add-architecture arm64 \
 
 # # Setup llvm sources
 # RUN echo "deb http://apt.llvm.org/$LLVM_DEBIAN_VERSION/ llvm-toolchain-$LLVM_DEBIAN_VERSION-$LLVM_VER  main" >> /etc/apt/sources.list.d/llvm.list
 # RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
-# RUN apt-get update
 #Install Clang dependencies
 #On bookworm clang is version 14, which is what we have as default.
 #Installing without versions here is convinient for scripts calling clang or lld instead of clang-14/lld-14
@@ -39,6 +38,15 @@ RUN apt-get install -y zip clang lldb lld clangd \
 	clang-$LLVM_VER lldb-$LLVM_VER lld-$LLVM_VER \
 	clangd-$LLVM_VER liblld-$LLVM_VER-dev \
 	llvm-$LLVM_VER-dev libpolly-$LLVM_VER-dev
+
+# Install llvm-lit, which we use for correctness tests
+RUN apt-get install -y python3-venv
+RUN python3 -m venv /opt/venv
+RUN /opt/venv/bin/python -m pip install --upgrade pip
+RUN /opt/venv/bin/python -m pip install pipx
+RUN /opt/venv/bin/pipx install lit
+RUN /opt/venv/bin/pipx ensurepath
+RUN /opt/venv/bin/pipx ensurepath --global
 
 ENV CARGO_HOME=/usr/local/cargo
 ENV RUSTUP_HOME=/usr/local/rustup

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update \
 			wget gnupg curl \
 			build-essential \
 			libz-dev \
-			gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+			gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+			python3-venv
 
 # dpkg --add-architecture arm64 \
 
@@ -40,13 +41,12 @@ RUN apt-get install -y zip clang lldb lld clangd \
 	llvm-$LLVM_VER-dev libpolly-$LLVM_VER-dev
 
 # Install llvm-lit, which we use for correctness tests
-RUN apt-get install -y python3-venv
-RUN python3 -m venv /opt/venv
-RUN /opt/venv/bin/python -m pip install --upgrade pip
-RUN /opt/venv/bin/python -m pip install pipx
-RUN /opt/venv/bin/pipx install lit
-RUN /opt/venv/bin/pipx ensurepath
-RUN /opt/venv/bin/pipx ensurepath --global
+RUN python3 -m venv /opt/venv \
+	&& /opt/venv/bin/python -m pip install --upgrade pip \
+	&& /opt/venv/bin/python -m pip install pipx \
+	&& /opt/venv/bin/pipx install lit \
+	&& /opt/venv/bin/pipx ensurepath \
+	&& /opt/venv/bin/pipx ensurepath --global
 
 ENV CARGO_HOME=/usr/local/cargo
 ENV RUSTUP_HOME=/usr/local/rustup

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get install -y zip clang lldb lld clangd \
 	llvm-$LLVM_VER-dev libpolly-$LLVM_VER-dev
 
 # Install llvm-lit, which we use for correctness tests
+ENV PIPX_BIN_DIR=/usr/local/bin
 RUN python3 -m venv /opt/venv \
 	&& /opt/venv/bin/python -m pip install --upgrade pip \
 	&& /opt/venv/bin/python -m pip install pipx \


### PR DESCRIPTION
Defining the `PIPX_BIN_DIR` environment variable allows us to change where pipx stores binaries at. Previously this was `~/.local/bin` but with this PR the directory has been changed to `/usr/local/bin`