### PR TITLE
ci: bump rust version to 1.90

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -6,7 +6,7 @@ FROM $BASE_IMAGE
 # Make sure we are on root
 USER root
 
-ARG RUST_VERSION=1.83
+ARG RUST_VERSION=1.90
 ARG LLVM_VER=14
 
 # Use the bullseye llvm version because there is no newer one yet

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -4,28 +4,29 @@ ARG BASE_IMAGE=mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION
 FROM $BASE_IMAGE
 
 ARG LLVM_VER=14.0.6
-ARG RUST_VER=1.83
-ARG 7ZIP_VERSION=2301
-ARG GIT_VERSION=2.43.0
-
-# Install VC++
+ARG RUST_VER=1.90
+ARG ZIP_VERSION=2501
+ARG GIT_VERSION=2.51.0
 
 WORKDIR C:/buildtools
 
+# Install VC++
 # Download channel for fixed install.
 ARG CHANNEL_URL=https://aka.ms/vs/17/release/channel
 ADD ${CHANNEL_URL} C:/TEMP/VisualStudio.chman
 
+# Download and install Build Tools for Visual Studio 2022 for native desktop workload.
 ADD https://aka.ms/vs/17/release/vs_buildtools.exe C:/TEMP/vs_buildtools.exe
-RUN C:/TEMP/vs_buildtools.exe --quiet --wait --norestart --nocache --installPath C:/buildtools \
-				# --all
-				--add Microsoft.Component.MSBuild \
-				--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
-				--add Microsoft.VisualStudio.Component.Windows10SDK.20348 
+RUN C:/TEMP/vs_buildtools.exe --quiet --wait --norestart --nocache \
+    --channelUri C:/TEMP/VisualStudio.chman \
+    --installChannelUri C:/TEMP/VisualStudio.chman \
+    --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended \
+    --installPath C:/BuildTools
+
 
 SHELL ["C:\\buildtools\\Common7\\Tools\\VsDevCmd.bat", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
 
-RUN Invoke-WebRequest -UserAgent 'DockerCI' -outfile 7zsetup.exe https://www.7-zip.org/a/7z$env:7ZIP_VERSION-x64.exe
+RUN Invoke-WebRequest -UserAgent 'DockerCI' -outfile 7zsetup.exe https://www.7-zip.org/a/7z$env:ZIP_VERSION-x64.exe
 RUN Invoke-WebRequest -UserAgent 'DockerCI' github.com/ghaith/llvm-package-windows/releases/download/v$env:LLVM_VER/LLVM-$env:LLVM_VER-win64.7z -outfile C:/TEMP/llvm.7z
 RUN Invoke-WebRequest -UserAgent 'DockerCI' https://win.rustup.rs -outfile C:/TEMP/rustup-init.exe
 RUN Invoke-WebRequest -UserAgent 'DockerCI' https://github.com/git-for-windows/git/releases/download/v$env:GIT_VERSION.windows.1/PortableGit-$env:GIT_VERSION-64-bit.7z.exe -outfile C:/TEMP/git-install.exe
@@ -33,6 +34,8 @@ RUN Invoke-WebRequest -UserAgent 'DockerCI' https://github.com/git-for-windows/g
 #Install 7zip
 RUN ./7zsetup /S /D=C:/buildtools/7z
 RUN setx /M PATH $($Env:PATH + ';C:/buildtools/7z/') 
+# Install git to use bash
+RUN 7z.exe x C:/TEMP/git-install.exe -ogit
 
 # Setup llvm sources
 ADD https://github.com/ghaith/llvm-package-windows/releases/download/v$LLVM_VER/LLVM-$LLVM_VER-win64.7z C:/TEMP/llvm.7z
@@ -51,7 +54,6 @@ RUN cargo install mdbook grcov cargo-nextest
 
 RUN setx /M PATH $($Env:PATH + ';C:/buildtools/llvm/bin') 
 
-RUN 7z.exe x C:/TEMP/git-install.exe -ogit
 
 #RUN cargo install cargo-watch #Activate this for local builds to enable watching
 WORKDIR C:/build


### PR DESCRIPTION
rust is now on 1.90
This will also allow us to move the edition to 2024