### PR TITLE
fix: install git/jq, rework :latest tagging, and unblock CI on auto PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,21 +57,30 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
-
-          # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "main" ] && VERSION=latest
-          #Add the platform to the version
-          VERSION=$VERSION-${{ matrix.config.arch }}
+          ARCH=${{ matrix.config.arch }}
+
+          # Determine which per-arch tags to publish:
+          #   - tag push   -> :<version>-<arch> AND :latest-<arch>  (releases own :latest)
+          #   - main push  -> :edge-<arch>                          (rolling main build)
+          REF=${{ github.ref }}
+          TAGS=()
+          if [[ "$REF" == "refs/tags/"* ]]; then
+            VERSION=$(echo "$REF" | sed -e 's,.*/\(.*\),\1,' -e 's/^v//')
+            TAGS+=("$VERSION-$ARCH" "latest-$ARCH")
+          elif [[ "$REF" == "refs/heads/main" ]]; then
+            TAGS+=("edge-$ARCH")
+          else
+            BRANCH=$(echo "$REF" | sed -e 's,.*/\(.*\),\1,')
+            TAGS+=("$BRANCH-$ARCH")
+          fi
+
           echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+          for TAG in "${TAGS[@]}"; do
+            echo "Publishing $IMAGE_ID:$TAG"
+            docker tag $IMAGE_NAME $IMAGE_ID:$TAG
+            docker push $IMAGE_ID:$TAG
+          done
   validate-windows:
     name: Validate Windows Dockerfile
     runs-on: ubuntu-latest
@@ -158,14 +167,23 @@ jobs:
         shell: bash
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
-
-          # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "main" ] && VERSION=latest
-          docker manifest create $IMAGE_ID:$VERSION $IMAGE_ID:$VERSION-arm64 $IMAGE_ID:$VERSION-x86_64
-          docker manifest push $IMAGE_ID:$VERSION
+
+          # Mirror the per-arch tag list from build-linux:
+          #   - tag push   -> multi-arch :<version> AND :latest
+          #   - main push  -> multi-arch :edge
+          REF=${{ github.ref }}
+          VERSIONS=()
+          if [[ "$REF" == "refs/tags/"* ]]; then
+            VERSION=$(echo "$REF" | sed -e 's,.*/\(.*\),\1,' -e 's/^v//')
+            VERSIONS+=("$VERSION" "latest")
+          elif [[ "$REF" == "refs/heads/main" ]]; then
+            VERSIONS+=("edge")
+          else
+            VERSIONS+=("$(echo "$REF" | sed -e 's,.*/\(.*\),\1,')")
+          fi
+
+          for V in "${VERSIONS[@]}"; do
+            docker manifest create $IMAGE_ID:$V $IMAGE_ID:$V-arm64 $IMAGE_ID:$V-x86_64
+            docker manifest push $IMAGE_ID:$V
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,18 @@ jobs:
     if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'update-deps'
     runs-on: ubuntu-latest
     steps:
+      # Mint a GitHub App token so the tag push fires docker.yml. The default
+      # GITHUB_TOKEN cannot trigger downstream workflows; App-minted tokens can.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Extract versions for tag
         id: version
@@ -37,6 +48,8 @@ jobs:
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -110,7 +110,18 @@ jobs:
     if: needs.check-updates.outputs.has_update == 'true' && (github.event_name != 'workflow_dispatch' || inputs.dry_run != true)
     runs-on: ubuntu-latest
     steps:
+      # Mint a GitHub App token so commits pushed to the PR branch trigger CI.
+      # The default GITHUB_TOKEN does not fire downstream workflows.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Update Dockerfiles
         env:
@@ -145,7 +156,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore: update dependencies"
           title: "Update dependencies"
           body: |

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -13,7 +13,7 @@ ARG RUST_VERSION=1.95.0
 # Install LLVM and its dependencies
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends wget curl gnupg build-essential lsb-release ca-certificates \
+    && apt-get install -y --no-install-recommends wget curl gnupg build-essential lsb-release ca-certificates git jq \
     && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh $LLVM_VERSION \
     && apt-get install -y --no-install-recommends clang lld liblld-$LLVM_VERSION-dev libpolly-$LLVM_VERSION-dev
 

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -38,18 +38,7 @@ RUN C:/TEMP/rustup-init.exe --default-toolchain %RUST_VERSION% -y `
 # Set PATH for Rust - VsDevCmd.bat already sets up MSVC paths
 RUN setx /M PATH "%PATH%;%USERPROFILE%\.cargo\bin"
 
-# Install cargo-binstall first, then use it to download pre-built binaries
-# This is faster and avoids hcsshim layer issues with large compile artifacts
-ADD https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-pc-windows-msvc.zip C:/TEMP/binstall.zip
-RUN powershell -Command "Expand-Archive -Path C:\TEMP\binstall.zip -DestinationPath C:\TEMP\binstall" `
-    && copy C:\TEMP\binstall\cargo-binstall.exe %USERPROFILE%\.cargo\bin\ `
-    && del /q C:\TEMP\binstall.zip `
-    && rmdir /s /q C:\TEMP\binstall
-
-# Install tools via binstall (pre-built binaries, no compilation)
-# Falls back to cargo install if no binary available
-RUN cargo binstall --no-confirm cargo-nextest grcov mdbook `
-    && (rmdir /s /q %USERPROFILE%\.cargo\registry 2>nul || echo "No registry to clean")
+RUN cargo install --locked cargo-nextest grcov mdbook
 
 RUN rustup component add llvm-tools-preview
 


### PR DESCRIPTION
## Summary
- Add `git` and `jq` to the Linux image. `git` was lost in the LLVM-21 Dockerfile rewrite (#26); `jq` was never installed. Both are tiny and de-facto required by common GitHub Actions tooling (e.g. `orhun/git-cliff-action`). Closes #31, #32.
- Rework `docker.yml` so `:latest` only moves on release-tag pushes. Main pushes now publish `:edge` (rolling) and tag pushes publish both `:<version>` and `:latest`. Going forward `:latest`'s digest will always equal some `v21-x.y` release-tag digest. Closes #33.
- Switch `release.yml` to mint a GitHub App token (`APP_ID` / `APP_PRIVATE_KEY`) so the auto-created tag actually triggers `docker.yml`. With the default `GITHUB_TOKEN`, tag pushes don't fire downstream workflows, which would have made the new tag-driven `:latest` logic silently never run for automated releases.
- Apply the same App-token swap to `update-versions.yml`'s `create-pr` job so commits on the auto-opened `update-deps` PR trigger CI.
- Revert the Windows image's tool install from `cargo binstall` back to `cargo install --locked`. `cargo binstall` resolves `index.crates.io` at install time, which has proven unreliable on some Windows container hosts; `cargo install --locked` doesn't need that lookup and matches the install path the previously-passing Windows images used.

## End-to-end flow after this PR

```
update-versions.yml ──opens PR──▶ release.yml ──pushes tag──▶ docker.yml
   (Monday 09:00 UTC)              (on PR merge)               (on tag push)
```

- `update-versions.yml`: weekly cron checks upstream Rust/LLVM/Git/7-Zip; if any moved, opens an `update-deps` PR. CI now actually runs on that PR.
- `release.yml`: when an `update-deps` PR merges, computes the tag from the merged Dockerfile and pushes it with the App token, which fires `docker.yml`.
- `docker.yml`: on tag push publishes `:<version>` + `:latest`; on main push publishes `:edge`; PRs build for validation only.

Net: `:latest` only changes when a release tag is published — typically once a Rust/LLVM release cycle. Between releases it's bit-stable. `:edge` tracks main.

## Test plan
- [ ] CI builds both arch images on this PR (pull-request trigger, no push).
- [ ] After merge: confirm push-to-main produces `:edge` / `:edge-x86_64` / `:edge-arm64` on GHCR, and does **not** overwrite `:latest`.
- [ ] On next release: confirm the auto-created tag triggers `docker.yml` and that `:latest` + `:<version>` are published with matching digests.
- [ ] On next Monday cron (or manual dispatch with `dry_run: false`): confirm the auto-opened `update-deps` PR has CI checks running on it.
- [ ] Inside the new Linux image: `git --version` and `jq --version` both report a version.
- [ ] Windows image builds reliably with `cargo install --locked` on hosts where `cargo binstall` was previously failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)